### PR TITLE
The PyPA has adopted the PSF code of conduct

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,4 +49,4 @@ Code of Conduct
 Everyone interacting on the wheel-builders mailing list and associated
 areas is expected to follow the `PSF Code of Conduct`_.
 
-.. PSF Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/
+.. PSF Code of Conduct: https://github.com/pypa/.github/blob/main/CODE_OF_CONDUCT.md

--- a/README.rst
+++ b/README.rst
@@ -49,4 +49,4 @@ Code of Conduct
 Everyone interacting on the wheel-builders mailing list and associated
 areas is expected to follow the `PSF Code of Conduct`_.
 
-.. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/
+.. PSF Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/

--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,6 @@ Code of Conduct
 ===============
 
 Everyone interacting on the wheel-builders mailing list and associated
-areas is expected to follow the `PyPA Code of Conduct`_.
+areas is expected to follow the `PSF Code of Conduct`_.
 
 .. _PyPA Code of Conduct: https://www.pypa.io/en/latest/code-of-conduct/


### PR DESCRIPTION
For details, see:

* https://discuss.python.org/t/implementing-pep-609-pypa-governance/4745